### PR TITLE
Add pdfplumber dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic
 python-slugify
 python-docx
 openpyxl
+pdfplumber


### PR DESCRIPTION
## Summary
- include pdfplumber in requirements for PDF processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2359e30388331a45ad8f3e5037124