### PR TITLE
Fix PDF upload parsing in Streamlit app

### DIFF
--- a/scripts/app_streamlit_descarguinator.py
+++ b/scripts/app_streamlit_descarguinator.py
@@ -218,7 +218,7 @@ if modo == "Crear caso nuevo":
             st.error("pdf_to_descargo no tiene función parse_pdf")
         else:
             try:
-                data = parser(uploaded_pdf.read())
+                data = parser(uploaded_pdf)
                 st.session_state.infrs = data.get("infracciones", [])
                 cli = data.get("cliente", {})
                 case_mapping = {"exp_juzgado": "JUZGADO", "exp_municipio": "MUNICIPIO", "exp_nro_causa": "NRO_CAUSA"}


### PR DESCRIPTION
## Summary
- pass uploaded file directly to `parse_pdf` instead of its raw bytes

## Testing
- `python -m py_compile scripts/app_streamlit_descarguinator.py scripts/pdf_to_descargo.py`
- `python scripts/pdf_to_descargo.py --help` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*
- `pip install pdfplumber` *(fails: Could not find a version that satisfies the requirement pdfplumber)*

------
https://chatgpt.com/codex/tasks/task_e_68b234c5a16c83318efd4157d0dbaf5b