### PR TITLE
Enable rendering multiple infractions from single JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+salidas/


### PR DESCRIPTION
## Summary
- support JSONs that group client info and multiple `infracciones`
- create descargo documents for each infraction, merging client data
- ignore generated `salidas/` outputs

## Testing
- `python -m py_compile scripts/descargos_render_v2.py`
- `python scripts/descargos_render_v2.py --caso /tmp/test_multi.json --estricto`


------
https://chatgpt.com/codex/tasks/task_e_68b375f86c148331a591912904494744