### PR TITLE
Fix dashboard metrics and streamline UI components

### DIFF
--- a/app/ui/components.py
+++ b/app/ui/components.py
@@ -1,15 +1,36 @@
+from pathlib import Path
 import streamlit as st
+
+
+def metric_card(label: str, value: int | str) -> None:
+    """Render a single metric card."""
+    st.metric(label, value)
+
+
+def _collect_stats(cases_root: Path) -> tuple[int, int, int]:
+    """Return counts for cases, json files and generated descargos."""
+    cases = [p for p in cases_root.iterdir() if p.is_dir()] if cases_root.exists() else []
+    jsons = list(cases_root.glob("*/json/*.json")) if cases_root.exists() else []
+    descargos = list(cases_root.glob("*/salidas/*.docx")) if cases_root.exists() else []
+    return len(cases), len(jsons), len(descargos)
 
 
 def render_dashboard() -> None:
     """Render cards and call-to-action buttons for the dashboard."""
+    base_dir = Path(__file__).resolve().parents[2]
+    cases_dir = base_dir / "casos"
+    cases, jsons, descargos = _collect_stats(cases_dir)
+
     col1, col2, col3 = st.columns(3)
     with col1:
-        st.metric("Casos", 0)
+        metric_card("Casos", cases)
     with col2:
-        st.metric("JSONs", 0)
+        metric_card("JSONs", jsons)
     with col3:
-        st.metric("Descargos", 0)
+        metric_card("Descargos", descargos)
 
-    st.button("Nuevo caso")
-    st.button("Actualizar")
+    col_btn1, col_btn2 = st.columns(2)
+    with col_btn1:
+        st.button("Nuevo caso")
+    with col_btn2:
+        st.button("Actualizar")

--- a/app/ui/layout.py
+++ b/app/ui/layout.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 import streamlit as st
-from . import theme
+
+
+def _logo_path() -> Path:
+    """Return the path to the sidebar logo."""
+    return Path(__file__).resolve().parents[1] / "assets" / "logo_rt.png"
+
 
 def sidebar() -> None:
     """Render the fixed sidebar with navigation and actions."""
-    logo = Path("app/assets/logo_rt.png")
+    logo = _logo_path()
     if logo.exists():
         st.sidebar.image(str(logo), use_column_width=True)
     st.sidebar.title("Navegación")


### PR DESCRIPTION
## Summary
- add `metric_card` component with dynamic stats for cases, JSONs and descargos
- compute stats from the filesystem and render buttons with columns
- resolve logo path in sidebar for resilient asset loading

## Testing
- `python -m py_compile app/ui/components.py app/app_streamlit_descarguinator.py app/ui/layout.py app/ui/theme.py`


------
https://chatgpt.com/codex/tasks/task_e_68c77d49f2f0833188c414c25c8d6631